### PR TITLE
[UX-603] Dependent gem changes

### DIFF
--- a/config/valid_email.yml
+++ b/config/valid_email.yml
@@ -3175,6 +3175,7 @@ disposable_email_services:
   - ghosttexter.de
   - girlsundertheinfluence.com
   - gishpuppy.com
+  - gmail.com
   - gowikibooks.com
   - gowikicampus.com
   - gowikicars.com

--- a/config/valid_email.yml
+++ b/config/valid_email.yml
@@ -3175,7 +3175,6 @@ disposable_email_services:
   - ghosttexter.de
   - girlsundertheinfluence.com
   - gishpuppy.com
-  - gmail.com
   - gowikibooks.com
   - gowikicampus.com
   - gowikicars.com
@@ -3537,3 +3536,23 @@ disposable_email_services:
   - zippymail.info
   - zoaxe.com
   - zoemail.org
+  # START
+  # see Make : app/assets/javascripts/akon/akon_user_form.js.coffee
+  - icloud.com
+  - me.com
+  - abv.com
+  - ymail.com
+  - mail.com
+  - gmail.com
+  - yahoo.com
+  - hotmail.com
+  - freemail.com
+  - outlook.com
+  - sogou.com
+  - googlemail.com
+  - rocketmail.com
+  - yandex.com
+  - redifmail.com
+  - libero.com
+  - live.com
+  # END

--- a/lib/valid_email/email_validator.rb
+++ b/lib/valid_email/email_validator.rb
@@ -10,14 +10,7 @@ class EmailValidator < ActiveModel::EachValidator
       m = Mail::Address.new(value)
       # We must check that value contains a domain and that value is an email address
       r = m.domain && m.address == value
-      t = m.__send__(:tree)
-      # We need to dig into treetop
-      # A valid domain must have dot_atom_text elements size > 1
-      # user@localhost is excluded
-      # treetop must respond to domain
-      # We exclude valid email values like <user@localhost.com>
-      # Hence we use m.__send__(tree).domain
-      r &&= (t.domain.dot_atom_text.elements.size > 1)
+      r &&= (m.domain.split('.').length > 1)
       # Check if domain has DNS MX record
       if r && options[:mx]
         require 'valid_email/mx_validator'

--- a/lib/valid_email/version.rb
+++ b/lib/valid_email/version.rb
@@ -1,2 +1,2 @@
-ValidEmailVersion = "0.0.7"
+ValidEmailVersion = "0.0.8"
 

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -147,6 +147,12 @@ describe EmailValidator do
         subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
+
+      it "should fail when email is gmail" do
+        subject.email = 'john@gmail.com'
+        subject.valid?.should be_falsey
+        subject.errors[:email].should == errors
+      end
     end
 
     describe "validating email from free service" do

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -61,37 +61,37 @@ describe EmailValidator do
       subject { person_class.new }
 
       it "should fail when email empty" do
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should fail when email is not valid" do
         subject.email = 'joh@doe'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should fail when email is valid with information" do
         subject.email = '"John Doe" <john@doe.com>'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should pass when email is simple email address" do
         subject.email = 'john@doe.com'
-        subject.valid?.should be_true
+        subject.valid?.should be_truthy
         subject.errors[:email].should be_empty
       end
 
       it "should fail when email is simple email address not stripped" do
         subject.email = 'john@doe.com            '
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should fail when passing multiple simple email addresses" do
         subject.email = 'john@doe.com, maria@doe.com'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
@@ -102,19 +102,19 @@ describe EmailValidator do
 
       it "should pass when email domain has MX record" do
         subject.email = 'john@gmail.com'
-        subject.valid?.should be_true
+        subject.valid?.should be_truthy
         subject.errors[:email].should be_empty
       end
 
       it "should fail when email domain has no MX record" do
         subject.email = 'john@subdomain.rubyonrails.org'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
 
       it "should fail when domain does not exists" do
         subject.email = 'john@nonexistentdomain.abc'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
     end
@@ -138,13 +138,13 @@ describe EmailValidator do
 
       it "should pass when email from trusted email services" do
         subject.email = 'john@mail.ru'
-        subject.valid?.should be_true
+        subject.valid?.should be_truthy
         subject.errors[:email].should be_empty
       end
 
       it "should fail when email from disposable email services" do
         subject.email = 'john@grr.la'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
     end
@@ -154,13 +154,13 @@ describe EmailValidator do
 
       it "should pass when email is from trusted email services" do
         subject.email = 'john@arealbusinessdomain.com'
-        subject.valid?.should be_true
+        subject.valid?.should be_truthy
         subject.errors[:email].should be_empty
       end
 
       it "should fail when email is from free email services" do
         subject.email = 'john@123.com'
-        subject.valid?.should be_false
+        subject.valid?.should be_falsey
         subject.errors[:email].should == errors
       end
     end

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -148,10 +148,13 @@ describe EmailValidator do
         subject.errors[:email].should == errors
       end
 
-      it "should fail when email is gmail" do
-        subject.email = 'john@gmail.com'
-        subject.valid?.should be_falsey
-        subject.errors[:email].should == errors
+      # see Make : app/assets/javascripts/akon/akon_user_form.js.coffee
+      ['icloud','me','abv','ymail','mail','gmail','yahoo','hotmail','freemail','outlook','sogou','googlemail','rocketmail','yandex','redifmail','libero','live'].each do |provider|
+        it "should fail when email is #{provider}" do
+          subject.email = "john@#{provider}.com"
+          subject.valid?.should be_falsey
+          subject.errors[:email].should == errors
+        end
       end
     end
 


### PR DESCRIPTION
@onewland CC @workshur 

Revulsion aside because we've forked [valid_email](https://github.com/hallelujah/valid_email) just to be able to modify the domains checked when a user signs up, these changes have to be made to prevent Contributors from signing up at https://make.crowdflower.com/users/new

- specs were failing, modernized syntax
- discovered gmail.com wasn't being prevented for creating account
- figured out the mechanism (ban_disposable_email) for doing such
- modified config file to include blocking gmail.com
- modified config file to include all other domains blocked by the frontend (in Make)

[UX-603](https://crowdflower.atlassian.net/browse/UX-603)

Akon app PR coming momentarily.